### PR TITLE
Fix security issues: OAuth state enforcement, upload ownership, secret key hardening

### DIFF
--- a/api/routes/auth.py
+++ b/api/routes/auth.py
@@ -66,6 +66,7 @@ def authorize(request: Request, code: str, state: str):
     state_previous = request.session.get('state')
     if state_previous != state:
         logger.warning(f"OAuth state mismatch — session: {state_previous!r}, incoming: {state!r}")
+        raise HTTPException(status_code=400, detail="OAuth state mismatch")
 
     try:
         access_token = sObj.getOAuth2AccessToken(code, settings.BASE_URL + "/authorize") # Must be the same URL configured in Splitwise website for redirection! (https://secure.splitwise.com/apps/3979)

--- a/api/routes/expense_upload.py
+++ b/api/routes/expense_upload.py
@@ -2,7 +2,7 @@ from splitwise.expense import Expense
 from splitwise.user import ExpenseUser
 
 from starlette.requests import Request
-from fastapi import APIRouter, Depends, Request, Form, UploadFile, File
+from fastapi import APIRouter, Depends, HTTPException, Request, Form, UploadFile, File
 from fastapi.responses import HTMLResponse
 from core.config.settings import get_settings
 from core.exceptions import handlers
@@ -177,8 +177,11 @@ def batch_upload_process(request: Request, db: Session = Depends(database.get_db
 def push_expenses(request: Request, upload_id: int, db: Session = Depends(database.get_db)):
 
     sObj = auth.get_access_token(request)
-        
+
     upload = crud.get_upload_by_id(db, upload_id = upload_id)
+    if upload is None or upload.creator_id != sObj.getCurrentUser().getId():
+        raise HTTPException(status_code=403, detail="Forbidden")
+
     expenses = crud.get_expenses_by_upload_id(db, upload_id = upload_id)
     group = crud.get_group_by_id(db, group_db_id = upload.group_id) # DB ID, not SW ID
 

--- a/core/config/settings.py
+++ b/core/config/settings.py
@@ -11,7 +11,7 @@ class Settings(BaseSettings):
 
     CONSUMER_KEY: str
     CONSUMER_SECRET: str
-    SECRET_KEY: str = "super-secret"
+    SECRET_KEY: str  # required — must be set in .env, no default
 
 
     @property

--- a/main.py
+++ b/main.py
@@ -103,8 +103,8 @@ def create_expense(request: Request, db: Session = Depends(database.get_db)):
 def get_uploads_by_id(request: Request, db: Session = Depends(database.get_db)):
     """Get uploads of the current user logged in the app, using it's user ID"""
     sObj = auth.get_access_token(request)
-    sObj.getCurrentUser().id
-    uploads = crud.get_uploads(db)
+    current_user_id = sObj.getCurrentUser().getId()
+    uploads = crud.get_uploads_by_sw_user_id(db, sw_user_id=current_user_id)
     return templates.TemplateResponse("uploads.html", {"request": request, "uploads" : uploads})
 
 @app.get("/groups", name = "groups", response_class=HTMLResponse)

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -63,22 +63,24 @@ class TestGetAccessToken:
 class TestAuthorizeRoute:
     def test_token_exchange_exception_shows_error(self):
         """`getOAuth2AccessToken` raising an exception renders the error page."""
+        cookie = make_session_cookie({"state": "xyz"})
         with patch("api.routes.auth.Splitwise") as MockSW:
             MockSW.return_value.getOAuth2AccessToken.side_effect = Exception("network error")
-            response = client.get("/authorize", params={"code": "abc", "state": "xyz"})
+            response = client.get("/authorize", params={"code": "abc", "state": "xyz"}, cookies={"session": cookie})
         assert response.status_code == 200
         assert "Could not complete authorization" in response.text
 
     def test_none_token_shows_error(self):
         """`getOAuth2AccessToken` returning None renders the error page."""
+        cookie = make_session_cookie({"state": "xyz"})
         with patch("api.routes.auth.Splitwise") as MockSW:
             MockSW.return_value.getOAuth2AccessToken.return_value = None
-            response = client.get("/authorize", params={"code": "abc", "state": "xyz"})
+            response = client.get("/authorize", params={"code": "abc", "state": "xyz"}, cookies={"session": cookie})
         assert response.status_code == 200
         assert "Splitwise denied" in response.text
 
-    def test_state_mismatch_logs_warning_but_succeeds(self, caplog):
-        """State mismatch logs a WARNING but the auth flow completes."""
+    def test_state_mismatch_returns_400(self, caplog):
+        """State mismatch logs a WARNING and returns 400 — flow must not complete."""
         cookie = make_session_cookie({"state": "correct_state"})
         with patch("api.routes.auth.Splitwise") as MockSW:
             mock_obj = MagicMock()
@@ -91,17 +93,18 @@ class TestAuthorizeRoute:
                     params={"code": "abc", "state": "wrong_state"},
                     cookies={"session": cookie},
                 )
-        assert response.status_code == 200
+        assert response.status_code == 400
         assert any("state mismatch" in r.message.lower() for r in caplog.records)
 
     def test_successful_auth_renders_success_page(self):
         """Successful OAuth flow renders authorize_success.html."""
+        cookie = make_session_cookie({"state": "xyz"})
         with patch("api.routes.auth.Splitwise") as MockSW:
             mock_obj = MagicMock()
             MockSW.return_value = mock_obj
             mock_obj.getOAuth2AccessToken.return_value = FAKE_TOKEN
             mock_obj.getCurrentUser.return_value = MagicMock(id=42, first_name="Test")
-            response = client.get("/authorize", params={"code": "abc", "state": "xyz"})
+            response = client.get("/authorize", params={"code": "abc", "state": "xyz"}, cookies={"session": cookie})
         assert response.status_code == 200
         assert "authorize_success" in response.template.name
 


### PR DESCRIPTION
## Summary
- **Enforce OAuth state check** — state mismatch now returns HTTP 400 instead of logging a warning and continuing, preventing CSRF on the auth callback
- **Upload ownership guard in `push_expenses`** — returns 403 if the upload doesn't belong to the current user, preventing horizontal privilege escalation
- **Remove `SECRET_KEY` default** — eliminates the hardcoded `"super-secret"` fallback; app fails fast at startup if the key is missing from `.env`
- **Scope `/uploads` to current user** — was returning all uploads from the DB; now filters by the logged-in Splitwise user ID

## Test plan
- [ ] Run existing test suite: `python -m unittest tests.test_auth`
- [ ] Verify OAuth flow still completes successfully with matching state
- [ ] Verify a state mismatch (tampered `state` param) returns 400
- [ ] Verify accessing another user's upload returns 403
- [ ] Confirm app fails to start without `SECRET_KEY` set in `.env`

🤖 Generated with [Claude Code](https://claude.com/claude-code)